### PR TITLE
Fix UnicodeDecodeError for Python 2.7

### DIFF
--- a/unsymlink-lib
+++ b/unsymlink-lib
@@ -14,7 +14,7 @@ import sys
 
 def decode(value):
     if isinstance(value, bytes):
-        return value.decode('utf-8', errors='backslashreplace')
+        return value.decode('utf-8', errors='replace')
     return value
 
 


### PR DESCRIPTION
Hi @mgorny,

Unlike `replace`, `backslashreplace` doesn't work for Python 2.7.

```python
>>> import sys
>>> print(sys.version)
2.7.16 (default, Mar  6 2019, 01:36:58)
[GCC 8.3.0]
>>> b'test\x80.txt'.decode('utf-8', errors='replace')
u'test\ufffd.txt'
>>> b'test\x80.txt'.decode('utf-8', errors='backslashreplace')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
TypeError: don't know how to handle UnicodeDecodeError in error callback
```