### PR TITLE
Optionally use hardlinks instead of copying the files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ check:
 	+$(MAKE) TEST=00rmkeepfiles check-docker
 	# check python2.7
 	+$(MAKE) EPYTHON=python2.7 check-docker
+	# Check for hardlink instead of copy
+	+$(MAKE) TEST=02hardlink check-docker
+	+$(MAKE) STAGE=gentoo/stage3-amd64-nomultilib TEST=02hardlink check-docker
 	$(DOCKER_CLEANUP)
 	# check whether utf-8 filenames don't kill it
 	+$(MAKE) TEST=01utf8 check-docker

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ BINDIR = $(PREFIX)/bin
 # test defaults
 TEST = 00basic
 STAGE = gentoo/stage3-amd64
+# A tag known to have an unmigrated stage3, with passing tests.
+STAGE_TAG = 20190619
+PORTAGE_TAG = 20190618
 EPYTHON = python3.6
 LANG = C.UTF-8
 
@@ -17,7 +20,8 @@ distclean:
 
 check-docker:
 	docker build -f docker/$(TEST)/Dockerfile \
-		--build-arg STAGE=$(STAGE) \
+		--build-arg STAGE=$(STAGE):$(STAGE_TAG) \
+		--build-arg PORTAGE_TAG=$(PORTAGE_TAG) \
 		--build-arg EPYTHON=$(EPYTHON) \
 		--build-arg LANG=$(LANG) .
 

--- a/docker/01utf8/Dockerfile
+++ b/docker/01utf8/Dockerfile
@@ -1,5 +1,6 @@
 ARG STAGE
-FROM gentoo/portage AS portdir
+ARG PORTAGE_TAG
+FROM gentoo/portage:${PORTAGE_TAG} AS portdir
 FROM ${STAGE}
 
 RUN mkdir -p /usr/portage/metadata \

--- a/docker/02hardlink/Dockerfile
+++ b/docker/02hardlink/Dockerfile
@@ -1,0 +1,11 @@
+ARG STAGE
+FROM ${STAGE}
+
+# silence the warning
+RUN mkdir /usr/portage
+ARG EPYTHON
+RUN ${EPYTHON} --version
+COPY unsymlink-lib /usr/local/bin
+RUN ${EPYTHON} /usr/local/bin/unsymlink-lib --analyze \
+	&& ${EPYTHON} /usr/local/bin/unsymlink-lib --migrate --hardlink \
+	&& ${EPYTHON} /usr/local/bin/unsymlink-lib --finish

--- a/docker/02nonutf8/Dockerfile
+++ b/docker/02nonutf8/Dockerfile
@@ -1,5 +1,6 @@
 ARG STAGE
-FROM gentoo/portage AS portdir
+ARG PORTAGE_TAG
+FROM gentoo/portage:${PORTAGE_TAG} AS portdir
 FROM ${STAGE}
 
 RUN mkdir -p /usr/portage/metadata \

--- a/unsymlink-lib
+++ b/unsymlink-lib
@@ -383,7 +383,7 @@ class MigrationState(object):
             log('can unmount the relevant file systems, rerun the script (including rerunning')
             log('--analyze!) and migrate them manually afterwards.')
 
-    def migrate(self, pretend):
+    def migrate(self, pretend, hardlink=False):
         try:
             # create the lib.new directories
             for prefix in self.prefixes:
@@ -398,7 +398,8 @@ class MigrationState(object):
 
                 if not pretend:
                     log('[{}] & {} -> {} ...', lib32, lib, lib_new)
-                cmd = [b'cp', b'-a', b'--reflink=auto', b'--']
+                link_flag = b'--link' if hardlink else b'--reflink=auto'
+                cmd = [b'cp', b'-a', link_flag, b'--']
                 if os.path.isdir(lib32):
                     cmd.append(os.path.join(lib32, b'.'))
                 # include all appropriate pure&mixed lib stuff
@@ -672,6 +673,8 @@ def main():
     g = argp.add_argument_group('expert options')
     g.add_argument('-P', '--prefix',
                    help='Migrate only the specified prefix directory (EXPERT)')
+    g.add_argument('--hardlink', action='store_true',
+                   help='Use hard links instead of copying (EXPERT)')
     args = argp.parse_args()
 
     is_root = os.geteuid() == 0
@@ -745,7 +748,7 @@ def main():
             return 1
         if args.pretend:
             log('Those are the actions that would be performed:')
-        m.migrate(pretend=args.pretend)
+        m.migrate(pretend=args.pretend, hardlink=args.hardlink)
         if not args.pretend:
             log('')
             log('')


### PR DESCRIPTION
See #10: on some space-constrained systems, copying the whole tree saturates available disk space.

Some flags are already set to enable copy-on-write on compatible filesystems; this patch adds an extra option to have a similar behaviour on non-cow-enabled filesystems.

Tests are provided, although a couple of changes were required to run tests against non-17.1-migrated profiles.